### PR TITLE
fix missing config, fixing breaking change in v1.3

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,0 +1,12 @@
+---
+Name: googlemaps
+---
+SiteConfig:
+  extensions:
+    - GoogleMapSiteConfig
+SiteTree:
+  extensions:
+    - GoogleMapSiteTree
+ContentController:
+  extensions:
+    - GoogleMapController


### PR DESCRIPTION
Version 1.3 introduced a breaking change in 1dfeb63c489c549b0a710a2968f2c759b67627f8 by removing the configurations of the extensions completely. 
This commit adds the configuration back into the module.